### PR TITLE
[Alternate] HtmlTable interface and implementation

### DIFF
--- a/src/main/java/com/redhat/darcy/web/HtmlTable.java
+++ b/src/main/java/com/redhat/darcy/web/HtmlTable.java
@@ -70,7 +70,7 @@ import java.util.Set;
  * </pre></code>
  */
 public class HtmlTable extends AbstractViewElement implements Table<HtmlTable>, HtmlElement {
-    public static interface Column<T> extends ColumnDefinition<HtmlTable, T> {
+    public static interface Column<T> extends Table.Column<HtmlTable, T> {
         static Column<String> text(int col) {
             return (t, r) -> t.getContext().find().text(byRowColumn(t, r, col)).getText();
         }

--- a/src/main/java/com/redhat/darcy/web/JQueryDataTable.java
+++ b/src/main/java/com/redhat/darcy/web/JQueryDataTable.java
@@ -26,12 +26,12 @@ import static org.hamcrest.Matchers.equalTo;
 
 import com.redhat.darcy.ui.AbstractViewElement;
 import com.redhat.darcy.ui.DarcyException;
-import com.redhat.darcy.ui.annotations.Context;
 import com.redhat.darcy.ui.annotations.Require;
 import com.redhat.darcy.ui.api.Locator;
 import com.redhat.darcy.ui.api.elements.Element;
 import com.redhat.darcy.ui.api.elements.Label;
 import com.redhat.darcy.ui.api.elements.PaginatedSortableTable;
+import com.redhat.darcy.ui.api.elements.Table;
 import com.redhat.darcy.ui.matchers.ViewMatchers;
 import com.redhat.darcy.web.api.WebContext;
 import com.redhat.darcy.web.api.elements.HtmlLink;
@@ -42,7 +42,7 @@ import java.util.regex.Pattern;
 
 public class JQueryDataTable extends AbstractViewElement implements
         PaginatedSortableTable<JQueryDataTable> {
-    public static interface Column<T> extends ColumnDefinition<JQueryDataTable, T> {
+    public static interface Column<T> extends Table.Column<JQueryDataTable, T> {
         static Column<String> text(int col) {
             return (t, r) -> t.getContext().find().text(byRowColumn(t, r, col)).getText();
         }


### PR DESCRIPTION
Building off the work from #11 , this is an alternate implementation that does not rely on inheritance to give columns access to the byInner of a specific table implementation.

Instead, table implementations are expected to provide Locator factory methods that work with that table type to return a locator to a specific cell or header. Column implementations can use these to locate their cells. Unless of course the table has been programmed with id's or some other means of finding the individual cells/header, then column implementations can simply look for those.

I've also provided an interface and static factory methods within it to help when creating common column types. Might expand on this some more.
