### PR TITLE
Add Browser#openAndWait for convenience(Fixes #28)

### DIFF
--- a/src/main/java/com/redhat/darcy/web/api/Browser.java
+++ b/src/main/java/com/redhat/darcy/web/api/Browser.java
@@ -22,6 +22,9 @@ package com.redhat.darcy.web.api;
 import com.redhat.darcy.ui.api.View;
 import com.redhat.darcy.ui.api.elements.Findable;
 import com.redhat.synq.Event;
+
+import java.time.Duration;
+
 /**
  * Abstracts all of the interactions a user might make with a browser.
  */
@@ -46,6 +49,23 @@ public interface Browser extends WebContext, Findable {
      */
     default <T extends View> Event<T> open(ViewUrl<T> viewUrl) {
         return open(viewUrl.url(), viewUrl.destination());
+    }
+
+    /**
+     * Constructs an {@link com.redhat.synq.Event} that will opens the URL and block until the
+     * associated {@link com.redhat.darcy.ui.api.View} is loaded, as defined by the {@link ViewUrl}
+     * parameter, and then calls {@link Event#waitUpTo(java.time.Duration)} to open the url and
+     * block the thread until the view is loaded. Will block the thread for a maximum of the
+     * specified duration, at which point a {@link com.redhat.synq.TimeoutException} will be
+     * thrown.
+     * @param viewUrl If you don't have a {@link com.redhat.darcy.web.api.ViewUrl} instance, but you
+     * know the url and the resulting {@link com.redhat.darcy.ui.api.View}, see
+     * {@link #open(String, com.redhat.darcy.ui.api.View)}.
+     * @param duration Maximum specified duration of the view loading
+     * @return The awaited view once it has met all criteria for loading
+     */
+    default <T extends View> T openAndWait(ViewUrl<T> viewUrl, Duration duration) {
+        return open(viewUrl).waitUpTo(duration);
     }
 
     /**

--- a/src/main/java/com/redhat/darcy/web/api/Browser.java
+++ b/src/main/java/com/redhat/darcy/web/api/Browser.java
@@ -72,34 +72,31 @@ public interface Browser extends WebContext, Findable {
     <T extends View> Event<T> open(String url, T destination);
 
     /**
-     * Constructs an {@link com.redhat.synq.Event} that will opens the URL and block until the
-     * associated {@link com.redhat.darcy.ui.api.View} is loaded, as defined by the {@link ViewUrl}
-     * parameter, and then calls {@link Event#waitUpTo(java.time.Duration)} to open the url. Will
-     * block the thread for a maximum of the specified duration, at which point a
-     * {@link com.redhat.synq.TimeoutException} will be thrown.
+     * Opens the URL and immediately blocks the thread for a maximum of the specified
+     * duration, after which a {@link com.redhat.synq.TimeoutException} will be thrown.
      * @param viewUrl If you don't have a {@link com.redhat.darcy.web.api.ViewUrl} instance, but you
      * know the url and the resulting {@link com.redhat.darcy.ui.api.View}, see
      * {@link #open(String, com.redhat.darcy.ui.api.View)}.
      * @param duration Maximum specified duration of the view loading
      * @return The awaited view once it has met all criteria for loading
      */
-    default <T extends View> T openAndWait(ViewUrl<T> viewUrl, Duration duration) {
+    default <T extends View> T openAndWaitUpTo(ViewUrl<T> viewUrl, Duration duration) {
         return open(viewUrl).waitUpTo(duration);
     }
 
     /**
-     * Constructs an {@link com.redhat.synq.Event} that will opens the URL and block until the
-     * associated {@link com.redhat.darcy.ui.api.View} is loaded, as defined by the {@link ViewUrl}
-     * parameter, and then calls {@link Event#waitUpTo(java.time.Duration)} with a default value to
-     * open the url. Will block the thread for a maximum of the two minutes, at which point a
-     * {@link com.redhat.synq.TimeoutException} will be thrown.
+     * Opens the URL and immediately blocks the thread for a maximum of the duration of the
+     * specified amount of units, after which a {@link com.redhat.synq.TimeoutException} will be
+     * thrown.
      * @param viewUrl If you don't have a {@link com.redhat.darcy.web.api.ViewUrl} instance, but you
      * know the url and the resulting {@link com.redhat.darcy.ui.api.View}, see
      * {@link #open(String, com.redhat.darcy.ui.api.View)}.
+     * @param amount The amount of the duration, expressed in units
+     * @param unit The unit the duration is measured in
      * @return The awaited view once it has met all criteria for loading
      */
-    default <T extends View> T openAndWait(ViewUrl<T> viewUrl) {
-        return open(viewUrl).waitUpTo(Duration.of(2, ChronoUnit.MINUTES));
+    default <T extends View> T openAndWaitUpTo(ViewUrl<T> viewUrl, Long amount, ChronoUnit unit) {
+        return open(viewUrl).waitUpTo(Duration.of(amount, unit));
     }
 
     /**

--- a/src/main/java/com/redhat/darcy/web/api/Browser.java
+++ b/src/main/java/com/redhat/darcy/web/api/Browser.java
@@ -24,6 +24,7 @@ import com.redhat.darcy.ui.api.elements.Findable;
 import com.redhat.synq.Event;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 /**
  * Abstracts all of the interactions a user might make with a browser.
@@ -52,23 +53,6 @@ public interface Browser extends WebContext, Findable {
     }
 
     /**
-     * Constructs an {@link com.redhat.synq.Event} that will opens the URL and block until the
-     * associated {@link com.redhat.darcy.ui.api.View} is loaded, as defined by the {@link ViewUrl}
-     * parameter, and then calls {@link Event#waitUpTo(java.time.Duration)} to open the url and
-     * block the thread until the view is loaded. Will block the thread for a maximum of the
-     * specified duration, at which point a {@link com.redhat.synq.TimeoutException} will be
-     * thrown.
-     * @param viewUrl If you don't have a {@link com.redhat.darcy.web.api.ViewUrl} instance, but you
-     * know the url and the resulting {@link com.redhat.darcy.ui.api.View}, see
-     * {@link #open(String, com.redhat.darcy.ui.api.View)}.
-     * @param duration Maximum specified duration of the view loading
-     * @return The awaited view once it has met all criteria for loading
-     */
-    default <T extends View> T openAndWait(ViewUrl<T> viewUrl, Duration duration) {
-        return open(viewUrl).waitUpTo(duration);
-    }
-
-    /**
      * Constructs an event that will opens the URL and block until the associated
      * {@link com.redhat.darcy.ui.api.View} is loaded, as defined by the {@link ViewUrl} parameter.
      * Note that merely calling this function does not actually <em>open</em> the URL and wait. You
@@ -86,6 +70,39 @@ public interface Browser extends WebContext, Findable {
      * @return An {@link com.redhat.synq.Event} that can be further configured and awaited.
      */
     <T extends View> Event<T> open(String url, T destination);
+
+    /**
+     * Constructs an {@link com.redhat.synq.Event} that will opens the URL and block until the
+     * associated {@link com.redhat.darcy.ui.api.View} is loaded, as defined by the {@link ViewUrl}
+     * parameter, and then calls {@link Event#waitUpTo(java.time.Duration)} to open the url and
+     * block the thread until the view is loaded. Will block the thread for a maximum of the
+     * specified duration, at which point a {@link com.redhat.synq.TimeoutException} will be
+     * thrown.
+     * @param viewUrl If you don't have a {@link com.redhat.darcy.web.api.ViewUrl} instance, but you
+     * know the url and the resulting {@link com.redhat.darcy.ui.api.View}, see
+     * {@link #open(String, com.redhat.darcy.ui.api.View)}.
+     * @param duration Maximum specified duration of the view loading
+     * @return The awaited view once it has met all criteria for loading
+     */
+    default <T extends View> T openAndWait(ViewUrl<T> viewUrl, Duration duration) {
+        return open(viewUrl).waitUpTo(duration);
+    }
+
+    /**
+     * Constructs an {@link com.redhat.synq.Event} that will opens the URL and block until the
+     * associated {@link com.redhat.darcy.ui.api.View} is loaded, as defined by the {@link ViewUrl}
+     * parameter, and then calls {@link Event#waitUpTo(java.time.Duration)} with a default value to
+     * open the url and block the thread until the view is loaded. Will block the thread for a
+     * maximum of the two minutes, at which point a {@link com.redhat.synq.TimeoutException} will be
+     * thrown.
+     * @param viewUrl If you don't have a {@link com.redhat.darcy.web.api.ViewUrl} instance, but you
+     * know the url and the resulting {@link com.redhat.darcy.ui.api.View}, see
+     * {@link #open(String, com.redhat.darcy.ui.api.View)}.
+     * @return The awaited view once it has met all criteria for loading
+     */
+    default <T extends View> T openAndWait(ViewUrl<T> viewUrl) {
+        return open(viewUrl).waitUpTo(Duration.of(2, ChronoUnit.MINUTES));
+    }
 
     /**
      * @return the current URL string this Browser window is pointing to.

--- a/src/main/java/com/redhat/darcy/web/api/Browser.java
+++ b/src/main/java/com/redhat/darcy/web/api/Browser.java
@@ -74,10 +74,9 @@ public interface Browser extends WebContext, Findable {
     /**
      * Constructs an {@link com.redhat.synq.Event} that will opens the URL and block until the
      * associated {@link com.redhat.darcy.ui.api.View} is loaded, as defined by the {@link ViewUrl}
-     * parameter, and then calls {@link Event#waitUpTo(java.time.Duration)} to open the url and
-     * block the thread until the view is loaded. Will block the thread for a maximum of the
-     * specified duration, at which point a {@link com.redhat.synq.TimeoutException} will be
-     * thrown.
+     * parameter, and then calls {@link Event#waitUpTo(java.time.Duration)} to open the url. Will
+     * block the thread for a maximum of the specified duration, at which point a
+     * {@link com.redhat.synq.TimeoutException} will be thrown.
      * @param viewUrl If you don't have a {@link com.redhat.darcy.web.api.ViewUrl} instance, but you
      * know the url and the resulting {@link com.redhat.darcy.ui.api.View}, see
      * {@link #open(String, com.redhat.darcy.ui.api.View)}.
@@ -92,9 +91,8 @@ public interface Browser extends WebContext, Findable {
      * Constructs an {@link com.redhat.synq.Event} that will opens the URL and block until the
      * associated {@link com.redhat.darcy.ui.api.View} is loaded, as defined by the {@link ViewUrl}
      * parameter, and then calls {@link Event#waitUpTo(java.time.Duration)} with a default value to
-     * open the url and block the thread until the view is loaded. Will block the thread for a
-     * maximum of the two minutes, at which point a {@link com.redhat.synq.TimeoutException} will be
-     * thrown.
+     * open the url. Will block the thread for a maximum of the two minutes, at which point a
+     * {@link com.redhat.synq.TimeoutException} will be thrown.
      * @param viewUrl If you don't have a {@link com.redhat.darcy.web.api.ViewUrl} instance, but you
      * know the url and the resulting {@link com.redhat.darcy.ui.api.View}, see
      * {@link #open(String, com.redhat.darcy.ui.api.View)}.


### PR DESCRIPTION
I'm not sure what the best way to make the predetermined duration for `openAndWait(ViewUrl<T> viewUrl` configurable.  Also not sure if you wanted to add javadocs here, but I gave it a shot.