### PR TITLE
Refactor screenshot API to use OutputStream (fixes #43)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,5 +78,11 @@
           <version>1.10.8</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.redhat.darcy</groupId>
     <artifactId>darcy-web</artifactId>
-    <version>0.2.3-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/redhat/darcy/web/api/Browser.java
+++ b/src/main/java/com/redhat/darcy/web/api/Browser.java
@@ -145,16 +145,16 @@ public interface Browser extends FindableWebContext {
     void closeAll();
 
     /**
-     * Takes a screenshot.
-     *
-     * Implementations should handle closing the {@link OutputStream}.
-     * @param outputStream The {@link OutputStream} to write the bytes to.
+     * Takes a screenshot as bytes and writes to the provided {@link OutputStream}.
+     * <p>
+     * Implementations should handle the output format of the image along with closing
+     * the {@link OutputStream}.
      */
     void takeScreenshot(OutputStream outputStream);
 
     /**
-     * Takes a screenshot and writes it to a file.
-     *
+     * Takes a screenshot and writes it to the provided {@link Path}.
+     * <p>
      * Any nonexistent directories included in the {@link Path} will be created.
      * An exception will not be thrown if the directories already exist.
      * @param path The {@link Path} of the desired file destination.

--- a/src/main/java/com/redhat/darcy/web/api/Browser.java
+++ b/src/main/java/com/redhat/darcy/web/api/Browser.java
@@ -22,7 +22,10 @@ package com.redhat.darcy.web.api;
 import com.redhat.darcy.ui.api.View;
 import com.redhat.synq.Event;
 
-import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 
@@ -140,7 +143,25 @@ public interface Browser extends FindableWebContext {
 
     void closeAll();
 
-    File takeScreenshot();
+    /**
+     * Takes a screenshot.
+     * @param outputStream The {@link OutputStream} to write the bytes to.
+     */
+    void takeScreenshot(OutputStream outputStream);
+
+    /**
+     * Takes a screenshot and writes it to a file.
+     * @param path The {@link Path} of the desired file destination.
+     */
+    default void takeScreenshot(Path path) {
+        try {
+            Files.createDirectories(path.getParent());
+            OutputStream fileOut = Files.newOutputStream(path);
+            takeScreenshot(fileOut);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 
     @Override
     WebSelection find();

--- a/src/main/java/com/redhat/darcy/web/api/Browser.java
+++ b/src/main/java/com/redhat/darcy/web/api/Browser.java
@@ -19,6 +19,7 @@
 
 package com.redhat.darcy.web.api;
 
+import com.redhat.darcy.ui.DarcyException;
 import com.redhat.darcy.ui.api.View;
 import com.redhat.synq.Event;
 
@@ -161,7 +162,7 @@ public interface Browser extends FindableWebContext {
             OutputStream fileOut = Files.newOutputStream(path);
             takeScreenshot(fileOut);
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new DarcyException("Could not take screenshot", e);
         }
     }
 

--- a/src/main/java/com/redhat/darcy/web/api/Browser.java
+++ b/src/main/java/com/redhat/darcy/web/api/Browser.java
@@ -146,14 +146,18 @@ public interface Browser extends FindableWebContext {
 
     /**
      * Takes a screenshot as bytes and writes to the provided {@link OutputStream}.
+     * Consumers should consult the implementation to see what image format the screenshot
+     * is written as.
      * <p>
-     * Implementations should handle the output format of the image along with closing
-     * the {@link OutputStream}.
+     * Implementations should handle closing the {@link OutputStream}.
      */
     void takeScreenshot(OutputStream outputStream);
 
     /**
-     * Takes a screenshot and writes it to the provided {@link Path}.
+     * Takes a screenshot and writes it to the provided {@link Path}. To determine
+     * what file extension to use in the provided {@link Path}, consumers should look
+     * to the documentation for the {@link #takeScreenshot(OutputStream)} implementation
+     * being used.
      * <p>
      * Any nonexistent directories included in the {@link Path} will be created.
      * An exception will not be thrown if the directories already exist.

--- a/src/main/java/com/redhat/darcy/web/api/Browser.java
+++ b/src/main/java/com/redhat/darcy/web/api/Browser.java
@@ -155,7 +155,9 @@ public interface Browser extends FindableWebContext {
      */
     default void takeScreenshot(Path path) {
         try {
-            Files.createDirectories(path.getParent());
+            if (path.getParent() != null) {
+                Files.createDirectories(path.getParent());
+            }
             OutputStream fileOut = Files.newOutputStream(path);
             takeScreenshot(fileOut);
         } catch (IOException e) {

--- a/src/main/java/com/redhat/darcy/web/api/Browser.java
+++ b/src/main/java/com/redhat/darcy/web/api/Browser.java
@@ -146,12 +146,17 @@ public interface Browser extends FindableWebContext {
 
     /**
      * Takes a screenshot.
+     *
+     * Implementations should handle closing the {@link OutputStream}.
      * @param outputStream The {@link OutputStream} to write the bytes to.
      */
     void takeScreenshot(OutputStream outputStream);
 
     /**
      * Takes a screenshot and writes it to a file.
+     *
+     * Any nonexistent directories included in the {@link Path} will be created.
+     * An exception will not be thrown if the directories already exist.
      * @param path The {@link Path} of the desired file destination.
      */
     default void takeScreenshot(Path path) {

--- a/src/test/java/com/redhat/darcy/web/TakeScreenshotTest.java
+++ b/src/test/java/com/redhat/darcy/web/TakeScreenshotTest.java
@@ -3,7 +3,10 @@ package com.redhat.darcy.web;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.redhat.darcy.ui.DarcyException;
 import com.redhat.darcy.web.stubs.FakeScreenshotTakingBrowser;
 
 import com.google.common.jimfs.Jimfs;
@@ -28,7 +31,35 @@ public class TakeScreenshotTest {
 
         browser.takeScreenshot(path);
 
-        assertTrue(Files.exists(path));
-        assertThat(Files.readAllBytes(path), equalTo(data));
+        assertTrue("Expected file to be created", Files.exists(path));
+        assertThat("Expected the correct data to be written to the file",
+                Files.readAllBytes(path), equalTo(data));
+    }
+
+    @Test
+    public void shouldWriteDataToPathWithParentDirectories() throws IOException {
+        byte[] data = new byte[] { 1, 2, 3 };
+        FakeScreenshotTakingBrowser browser = new FakeScreenshotTakingBrowser(data);
+
+        FileSystem fileSystem = Jimfs.newFileSystem();
+        Path path = fileSystem.getPath("parent/folder/example.png");
+
+        browser.takeScreenshot(path);
+
+        assertTrue("Expected parent directories to be created",
+                Files.exists(path.getParent()));
+        assertTrue("Expected file to be created", Files.exists(path));
+        assertThat("Expected the correct data to be written to the file",
+                Files.readAllBytes(path), equalTo(data));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = DarcyException.class)
+    public void shouldThrowDarcyExceptionWhenAnIOExceptionOccurs() {
+        FakeScreenshotTakingBrowser browser = new FakeScreenshotTakingBrowser(null);
+
+        Path path = mock(Path.class);
+        when(path.getParent()).thenThrow(IOException.class);
+        browser.takeScreenshot(path);
     }
 }

--- a/src/test/java/com/redhat/darcy/web/TakeScreenshotTest.java
+++ b/src/test/java/com/redhat/darcy/web/TakeScreenshotTest.java
@@ -1,0 +1,34 @@
+package com.redhat.darcy.web;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.redhat.darcy.web.stubs.FakeScreenshotTakingBrowser;
+
+import com.google.common.jimfs.Jimfs;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@RunWith(JUnit4.class)
+public class TakeScreenshotTest {
+    @Test
+    public void shouldWriteDataToPath() throws IOException {
+        byte[] data = new byte[] { 1, 2, 3 };
+        FakeScreenshotTakingBrowser browser = new FakeScreenshotTakingBrowser(data);
+
+        FileSystem fileSystem = Jimfs.newFileSystem();
+        Path path = fileSystem.getPath("example.png");
+
+        browser.takeScreenshot(path);
+
+        assertTrue(Files.exists(path));
+        assertThat(Files.readAllBytes(path), equalTo(data));
+    }
+}

--- a/src/test/java/com/redhat/darcy/web/stubs/FakeScreenshotTakingBrowser.java
+++ b/src/test/java/com/redhat/darcy/web/stubs/FakeScreenshotTakingBrowser.java
@@ -1,0 +1,90 @@
+package com.redhat.darcy.web.stubs;
+
+import com.redhat.darcy.ui.DarcyException;
+import com.redhat.darcy.ui.api.View;
+import com.redhat.darcy.web.api.Browser;
+import com.redhat.darcy.web.api.CookieManager;
+import com.redhat.darcy.web.api.WebSelection;
+import com.redhat.synq.Event;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class FakeScreenshotTakingBrowser implements Browser {
+    private byte[] data;
+
+    public FakeScreenshotTakingBrowser(byte[] data) {
+        this.data = data;
+    }
+
+    @Override
+    public <T extends View> Event<T> open(String url, T destination) {
+        throw new UnsupportedOperationException("open");
+    }
+
+    @Override
+    public String getCurrentUrl() {
+        throw new UnsupportedOperationException("getCurrentUrl");
+    }
+
+    @Override
+    public String getTitle() {
+        throw new UnsupportedOperationException("getTitle");
+    }
+
+    @Override
+    public String getSource() {
+        throw new UnsupportedOperationException("getSource");
+    }
+
+    @Override
+    public <T extends View> Event<T> back(T destination) {
+        throw new UnsupportedOperationException("back");
+    }
+
+    @Override
+    public <T extends View> Event<T> forward(T destination) {
+        throw new UnsupportedOperationException("forward");
+    }
+
+    @Override
+    public <T extends View> Event<T> refresh(T destination) {
+        throw new UnsupportedOperationException("refresh");
+    }
+
+    @Override
+    public CookieManager cookies() {
+        throw new UnsupportedOperationException("cookies");
+    }
+
+    @Override
+    public void close() {
+        throw new UnsupportedOperationException("close");
+    }
+
+    @Override
+    public void closeAll() {
+        throw new UnsupportedOperationException("closeAll");
+    }
+
+    @Override
+    public void takeScreenshot(OutputStream outputStream) {
+        try {
+            outputStream.write(data);
+            outputStream.flush();
+            outputStream.close();
+        } catch (IOException e) {
+            throw new DarcyException(e);
+        }
+    }
+
+    @Override
+    public WebSelection find() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isPresent() {
+        return false;
+    }
+}


### PR DESCRIPTION
JavaDocs could use a bit more finesse and detail: the `takeScreenshot(Path path)` could probably specify that you should pass in a `Path` of something like `folder/example.png`. Let me know how this looks so far. Thanks!